### PR TITLE
Fixing the version of nebulex_local on mix.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ add the following to your `mix.exs`:
 def deps do
   [
     {:nebulex, "~> 3.0.0-rc.1"},
-    {:nebulex_local, "~> 3.0"},  # Generational local cache adapter
-    {:decorator, "~> 1.4"},      # Required for caching decorators
-    {:telemetry, "~> 1.2"}       # Required for telemetry events
+    {:nebulex_local, "~> 3.0.0-rc.1"},  # Generational local cache adapter
+    {:decorator, "~> 1.4"},             # Required for caching decorators
+    {:telemetry, "~> 1.2"}              # Required for telemetry events
   ]
 end
 ```

--- a/lib/nebulex/adapter.ex
+++ b/lib/nebulex/adapter.ex
@@ -145,7 +145,7 @@ defmodule Nebulex.Adapter do
         args,
         opts
       ) do
-    opts = Options.validate_telemetry_opts!(opts)
+    opts = Options.validate_runtime_shared_opts!(opts)
     args = args ++ [opts]
 
     if telemetry? do

--- a/lib/nebulex/cache.ex
+++ b/lib/nebulex/cache.ex
@@ -393,7 +393,8 @@ defmodule Nebulex.Cache do
     quote do
       @behaviour Nebulex.Cache
 
-      {otp_app, adapter, behaviours, opts} = Nebulex.Cache.Supervisor.compile_config(unquote(opts))
+      {otp_app, adapter, behaviours, opts} =
+        Nebulex.Cache.Supervisor.compile_config(unquote(opts))
 
       @otp_app otp_app
       @adapter adapter

--- a/lib/nebulex/cache/options.ex
+++ b/lib/nebulex/cache/options.ex
@@ -235,9 +235,6 @@ defmodule Nebulex.Cache.Options do
   # Start options
   @start_link_opts Keyword.keys(@start_link_opts_schema.schema)
 
-  # Telemetry options schema
-  @telemetry_opts_schema NimbleOptions.new!(telemetry_opts)
-
   # Shared options schema
   @runtime_shared_opts_schema NimbleOptions.new!(runtime_shared_opts ++ telemetry_opts)
 
@@ -376,12 +373,12 @@ defmodule Nebulex.Cache.Options do
     Keyword.merge(opts, start_link_opts)
   end
 
-  @spec validate_telemetry_opts!(keyword()) :: keyword()
-  def validate_telemetry_opts!(opts) do
+  @spec validate_runtime_shared_opts!(keyword()) :: keyword()
+  def validate_runtime_shared_opts!(opts) do
     _ignore =
       opts
-      |> Keyword.take([:telemetry_event, :telemetry_metadata])
-      |> NimbleOptions.validate!(@telemetry_opts_schema)
+      |> Keyword.take(@runtime_shared_opts)
+      |> NimbleOptions.validate!(@runtime_shared_opts_schema)
 
     opts
   end


### PR DESCRIPTION
The current version of the README states to use `{:nebulex_local, "~> 3.0"}`, but this doesn't work as this version doesn't exist on Hex. To make it work, I needed to change the version to `{:nebulex_local, "~> 3.0.0-rc.1"}`.